### PR TITLE
Regex adjustment for valid paths

### DIFF
--- a/MareSynchronos/UI/UIShared.cs
+++ b/MareSynchronos/UI/UIShared.cs
@@ -410,7 +410,7 @@ namespace MareSynchronos.UI
                     _isPenumbraDirectory = path.ToLower() == _ipcManager.PenumbraModDirectory()?.ToLower();
                     _isDirectoryWritable = IsDirectoryWritable(path);
                     _cacheDirectoryHasOtherFilesThanCache = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Any(f => new FileInfo(f).Name.Length != 40);
-                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\(?:[\w\s\-\\])+?|\/(?:[\w\s\-]|[\/])+?)$");
+                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\[\w\s\-\\]+?|\/(?:[\w\s\-]|[\/])+?)$");
 
                     if (!string.IsNullOrEmpty(path)
                         && Directory.Exists(path)

--- a/MareSynchronos/UI/UIShared.cs
+++ b/MareSynchronos/UI/UIShared.cs
@@ -410,7 +410,7 @@ namespace MareSynchronos.UI
                     _isPenumbraDirectory = path.ToLower() == _ipcManager.PenumbraModDirectory()?.ToLower();
                     _isDirectoryWritable = IsDirectoryWritable(path);
                     _cacheDirectoryHasOtherFilesThanCache = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Any(f => new FileInfo(f).Name.Length != 40);
-                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(\w:\\(\w|\\| |-|_)*|\/(\w|\/| |-|_)*)");
+                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\(?:[\w\s\-]|[\\])+?|[\/]{1}(?:[\w\s\-]|[\/])+?)$");
 
                     if (!string.IsNullOrEmpty(path)
                         && Directory.Exists(path)

--- a/MareSynchronos/UI/UIShared.cs
+++ b/MareSynchronos/UI/UIShared.cs
@@ -410,7 +410,7 @@ namespace MareSynchronos.UI
                     _isPenumbraDirectory = path.ToLower() == _ipcManager.PenumbraModDirectory()?.ToLower();
                     _isDirectoryWritable = IsDirectoryWritable(path);
                     _cacheDirectoryHasOtherFilesThanCache = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Any(f => new FileInfo(f).Name.Length != 40);
-                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\[\w\s\-\\]+?|\/(?:[\w\s\-]|[\/])+?)$");
+                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\[\w\s\-\\]+?|\/(?:[\w\s\-\/])+?)$");
 
                     if (!string.IsNullOrEmpty(path)
                         && Directory.Exists(path)

--- a/MareSynchronos/UI/UIShared.cs
+++ b/MareSynchronos/UI/UIShared.cs
@@ -410,7 +410,7 @@ namespace MareSynchronos.UI
                     _isPenumbraDirectory = path.ToLower() == _ipcManager.PenumbraModDirectory()?.ToLower();
                     _isDirectoryWritable = IsDirectoryWritable(path);
                     _cacheDirectoryHasOtherFilesThanCache = Directory.GetFiles(path, "*", SearchOption.AllDirectories).Any(f => new FileInfo(f).Name.Length != 40);
-                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\(?:[\w\s\-]|[\\])+?|[\/]{1}(?:[\w\s\-]|[\/])+?)$");
+                    _cacheDirectoryHasIllegalCharacter = Regex.IsMatch(path, @"^(?:[a-zA-Z]:\\(?:[\w\s\-\\])+?|\/(?:[\w\s\-]|[\/])+?)$");
 
                     if (!string.IsNullOrEmpty(path)
                         && Directory.Exists(path)


### PR DESCRIPTION
This makes further adjustments to the Regex to allow for valid Windows and Linux paths.
- Valid Windows paths can necessarily contain spaces and hyphens as the game's installation path contains both. (eg. `\SquareEnix\FINAL FANTASY XIV - A Realm Reborn`) so a check for `\w` is insufficient
- Valid Linux paths can also be double-slashed (eg. `/path//to//file`)

In addition some pointless optimizations were made by making the groups non-capturing, lazy matching, and including an ending anchor. Because a valid path must necessarily include at least one valid character `*` was changed to `+`.