### PR TITLE
DTR entry: Hide --- separator if list is empty

### DIFF
--- a/MareSynchronos/UI/DtrEntry.cs
+++ b/MareSynchronos/UI/DtrEntry.cs
@@ -119,8 +119,19 @@ public sealed class DtrEntry : IDisposable, IHostedService
         string tooltip;
         if (_apiController.IsConnected)
         {
-            text = $"\uE044 {_pairManager.GetVisibleUserCount()}";
-            tooltip = $"Mare Synchronos: Connected{Environment.NewLine}----------{Environment.NewLine}{string.Join(Environment.NewLine, _pairManager.GetOnlineUserPairs().Where(x => x.IsVisible).Select(x => string.Format("{0} ({1})", x.PlayerName, x.UserData.AliasOrUID)))}";
+            var pairCount = _pairManager.GetVisibleUserCount();
+            text = $"\uE044 {pairCount}";
+            if (pairCount > 0)
+            {
+                var visiblePairs = _pairManager.GetOnlineUserPairs()
+                    .Where(x => x.IsVisible)
+                    .Select(x => string.Format("{0} ({1})", x.PlayerName, x.UserData.AliasOrUID));
+                tooltip = $"Mare Synchronos: Connected{Environment.NewLine}----------{Environment.NewLine}{string.Join(Environment.NewLine, visiblePairs)}";
+            }
+            else
+            {
+                tooltip = "Mare Synchronos: Connected";
+            }
         }
         else
         {


### PR DESCRIPTION
Avoids this quirk:
![image](https://github.com/Penumbra-Sync/client/assets/2236342/6ddbfdb5-d3ad-4659-96b3-5c57fde8c310)