### PR TITLE
Deny reading incomplete MCDFs

### DIFF
--- a/MareSynchronos/PlayerData/Export/MareCharaFileManager.cs
+++ b/MareSynchronos/PlayerData/Export/MareCharaFileManager.cs
@@ -194,7 +194,7 @@ public class MareCharaFileManager : DisposableMediatorSubscriberBase
             var mareCharaFileData = _factory.Create(description, dto);
             MareCharaFileHeader output = new(MareCharaFileHeader.CurrentVersion, mareCharaFileData);
 
-            using var fs = new FileStream(tempFilePath, FileMode.Create);
+            using var fs = new FileStream(tempFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Delete);
             using var lz4 = new LZ4Stream(fs, LZ4StreamMode.Compress, LZ4StreamFlags.HighCompression);
             using var writer = new BinaryWriter(lz4);
             output.WriteToStream(writer);


### PR DESCRIPTION
An additional safeguard, as I suggested on Discord.

Allows deleting the file before it's complete, because I see no point in restricting that, but prevents any process from reading/writing it until Mare is done with it.